### PR TITLE
Add aria labels for dark mode toggle

### DIFF
--- a/about.html
+++ b/about.html
@@ -22,7 +22,7 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <button id="themeBtn" title="Toggle dark mode">🌓</button>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
     </div>
   </header>
 

--- a/clean-v3.html
+++ b/clean-v3.html
@@ -25,7 +25,7 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <button id="themeBtn" title="Toggle dark mode">🌓</button>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
     </div>
   </header>
 

--- a/clean-v7.html
+++ b/clean-v7.html
@@ -25,7 +25,7 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <button id="themeBtn" title="Toggle dark mode">🌓</button>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
     </div>
   </header>
 

--- a/contact.html
+++ b/contact.html
@@ -22,7 +22,7 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <button id="themeBtn" title="Toggle dark mode">🌓</button>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
     </div>
   </header>
 

--- a/cycle-21.html
+++ b/cycle-21.html
@@ -25,7 +25,7 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <button id="themeBtn" title="Toggle dark mode">🌓</button>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
     </div>
   </header>
 

--- a/cystopil.html
+++ b/cystopil.html
@@ -25,7 +25,7 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <button id="themeBtn" title="Toggle dark mode">🌓</button>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
     </div>
   </header>
 

--- a/d3-nine.html
+++ b/d3-nine.html
@@ -25,7 +25,7 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <button id="themeBtn" title="Toggle dark mode">🌓</button>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
     </div>
   </header>
 

--- a/esokare-d.html
+++ b/esokare-d.html
@@ -25,7 +25,7 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <button id="themeBtn" title="Toggle dark mode">🌓</button>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
     </div>
   </header>
 

--- a/foljoy.html
+++ b/foljoy.html
@@ -25,7 +25,7 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <button id="themeBtn" title="Toggle dark mode">🌓</button>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
     </div>
   </header>
 

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <button id="themeBtn" title="Toggle dark mode">🌓</button>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
     </div>
   </header>
 

--- a/products.html
+++ b/products.html
@@ -22,7 +22,7 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <button id="themeBtn" title="Toggle dark mode">🌓</button>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
     </div>
   </header>
 

--- a/snoril-d.html
+++ b/snoril-d.html
@@ -25,7 +25,7 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <button id="themeBtn" title="Toggle dark mode">🌓</button>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
     </div>
   </header>
 

--- a/snoril-lx.html
+++ b/snoril-lx.html
@@ -25,7 +25,7 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <button id="themeBtn" title="Toggle dark mode">🌓</button>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
     </div>
   </header>
 

--- a/vitotop.html
+++ b/vitotop.html
@@ -25,7 +25,7 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <button id="themeBtn" title="Toggle dark mode">🌓</button>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- give the theme toggle buttons an `aria-label` attribute in all pages for accessibility

## Testing
- `grep -n "aria-label=\"Toggle dark mode\"" *.html`


------
https://chatgpt.com/codex/tasks/task_e_686ce68036148330b2eb5eccdbfd797a