### PR TITLE
Add meta descriptions and schema data

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,9 +3,18 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Learn about Astra Biocare Pvt Ltd, our mission and values." />
   <title>Astra Biocare Pvt Ltd - About Us</title>
   <link rel="stylesheet" href="style.css" />
   <script defer src="script.js"></script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "Astra Biocare Pvt Ltd",
+      "url": "https://www.astrabiocare.com"
+    }
+  </script>
 </head>
 <body>
   <header class="site-header">

--- a/clean-v3.html
+++ b/clean-v3.html
@@ -3,12 +3,22 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Discover CLEAN-V3 from Astra Biocare." />
   <title>CLEAN-V3 - Astra Biocare</title>
   <link rel="stylesheet" href="style.css" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
   <script defer src="script.js"></script>
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "CLEAN-V3",
+      "brand": "Astra Biocare",
+      "url": "https://www.astrabiocare.com/clean-v3.html"
+    }
+  </script>
 </head>
 <body>
   <header class="site-header">

--- a/clean-v7.html
+++ b/clean-v7.html
@@ -3,12 +3,22 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Discover CLEAN-V7 from Astra Biocare." />
   <title>CLEAN-V7 - Astra Biocare</title>
   <link rel="stylesheet" href="style.css" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
   <script defer src="script.js"></script>
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "CLEAN-V7",
+      "brand": "Astra Biocare",
+      "url": "https://www.astrabiocare.com/clean-v7.html"
+    }
+  </script>
 </head>
 <body>
   <header class="site-header">

--- a/contact.html
+++ b/contact.html
@@ -3,9 +3,18 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Contact Astra Biocare Pvt Ltd for product inquiries and support." />
   <title>Astra Biocare Pvt Ltd - Contact</title>
   <link rel="stylesheet" href="style.css" />
   <script defer src="script.js"></script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "Astra Biocare Pvt Ltd",
+      "url": "https://www.astrabiocare.com"
+    }
+  </script>
 </head>
 <body>
   <header class="site-header">

--- a/cycle-21.html
+++ b/cycle-21.html
@@ -3,12 +3,22 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Discover CYCLE-21 from Astra Biocare." />
   <title>CYCLE-21 - Astra Biocare</title>
   <link rel="stylesheet" href="style.css" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
   <script defer src="script.js"></script>
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "CYCLE-21",
+      "brand": "Astra Biocare",
+      "url": "https://www.astrabiocare.com/cycle-21.html"
+    }
+  </script>
 </head>
 <body>
   <header class="site-header">

--- a/cystopil.html
+++ b/cystopil.html
@@ -3,12 +3,22 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Discover CYSTOPIL from Astra Biocare." />
   <title>CYSTOPIL - Astra Biocare</title>
   <link rel="stylesheet" href="style.css" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
   <script defer src="script.js"></script>
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "CYSTOPIL",
+      "brand": "Astra Biocare",
+      "url": "https://www.astrabiocare.com/cystopil.html"
+    }
+  </script>
 </head>
 <body>
   <header class="site-header">

--- a/d3-nine.html
+++ b/d3-nine.html
@@ -3,12 +3,22 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Discover D3-NINE from Astra Biocare." />
   <title>D3-NINE - Astra Biocare</title>
   <link rel="stylesheet" href="style.css" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
   <script defer src="script.js"></script>
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "D3-NINE",
+      "brand": "Astra Biocare",
+      "url": "https://www.astrabiocare.com/d3-nine.html"
+    }
+  </script>
 </head>
 <body>
   <header class="site-header">

--- a/esokare-d.html
+++ b/esokare-d.html
@@ -3,12 +3,22 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Discover ESOKARE-D from Astra Biocare." />
   <title>ESOKARE-D - Astra Biocare</title>
   <link rel="stylesheet" href="style.css" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
   <script defer src="script.js"></script>
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "ESOKARE-D",
+      "brand": "Astra Biocare",
+      "url": "https://www.astrabiocare.com/esokare-d.html"
+    }
+  </script>
 </head>
 <body>
   <header class="site-header">

--- a/foljoy.html
+++ b/foljoy.html
@@ -3,12 +3,22 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Discover FOLJOY from Astra Biocare." />
   <title>FOLJOY - Astra Biocare</title>
   <link rel="stylesheet" href="style.css" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
   <script defer src="script.js"></script>
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "FOLJOY",
+      "brand": "Astra Biocare",
+      "url": "https://www.astrabiocare.com/foljoy.html"
+    }
+  </script>
 </head>
 <body>
   <header class="site-header">

--- a/snoril-d.html
+++ b/snoril-d.html
@@ -3,12 +3,22 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Discover SNORIL-D from Astra Biocare." />
   <title>SNORIL-D - Astra Biocare</title>
   <link rel="stylesheet" href="style.css" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
   <script defer src="script.js"></script>
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "SNORIL-D",
+      "brand": "Astra Biocare",
+      "url": "https://www.astrabiocare.com/snoril-d.html"
+    }
+  </script>
 </head>
 <body>
   <header class="site-header">

--- a/snoril-lx.html
+++ b/snoril-lx.html
@@ -3,12 +3,22 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Discover SNORIL-LX from Astra Biocare." />
   <title>SNORIL-LX - Astra Biocare</title>
   <link rel="stylesheet" href="style.css" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
   <script defer src="script.js"></script>
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "SNORIL-LX",
+      "brand": "Astra Biocare",
+      "url": "https://www.astrabiocare.com/snoril-lx.html"
+    }
+  </script>
 </head>
 <body>
   <header class="site-header">

--- a/vitotop.html
+++ b/vitotop.html
@@ -3,12 +3,22 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Discover VITOTOP from Astra Biocare." />
   <title>VITOTOP - Astra Biocare</title>
   <link rel="stylesheet" href="style.css" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
   <script defer src="script.js"></script>
   <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "VITOTOP",
+      "brand": "Astra Biocare",
+      "url": "https://www.astrabiocare.com/vitotop.html"
+    }
+  </script>
 </head>
 <body>
   <header class="site-header">


### PR DESCRIPTION
## Summary
- enhance `<head>` sections across pages with meta descriptions
- embed JSON-LD organization schema on about and contact pages
- add JSON-LD product schema on all product pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ce67a79c08330ab7ad52f5baf33a2