### PR TITLE
Move product HTML pages into products subfolder

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,7 +27,7 @@
       <nav>
         <ul class="nav-list">
           <li><a href="index.html">Home</a></li>
-          <li><a href="products.html">Products</a></li>
+          <li><a href="products/products.html">Products</a></li>
           <li><a href="about.html">About Us</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>

--- a/contact.html
+++ b/contact.html
@@ -27,7 +27,7 @@
       <nav>
         <ul class="nav-list">
           <li><a href="index.html">Home</a></li>
-          <li><a href="products.html">Products</a></li>
+          <li><a href="products/products.html">Products</a></li>
           <li><a href="about.html">About Us</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
       <nav>
         <ul class="nav-list">
           <li><a href="index.html">Home</a></li>
-          <li><a href="products.html">Products</a></li>
+          <li><a href="products/products.html">Products</a></li>
           <li><a href="about.html">About Us</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
@@ -38,7 +38,7 @@
         <p>
           Astra Biocare is committed to delivering innovative and high-quality pharmaceutical products to enhance global well-being.
         </p>
-        <a href="products.html" class="btn-primary">Explore Products</a>
+        <a href="products/products.html" class="btn-primary">Explore Products</a>
       </div>
       <div class="hero-img">
         <img src="img/hero_medicines.jpg" alt="Pharmaceutical Products" />
@@ -61,7 +61,7 @@
           <h3>SNORIL-LX</h3>
         </div>
       </div>
-      <a href="products.html" class="btn-secondary">View All Products</a>
+      <a href="products/products.html" class="btn-secondary">View All Products</a>
     </section>
 
     <section class="about-preview" data-aos="fade-right">

--- a/products/clean-v3.html
+++ b/products/clean-v3.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Discover ESOKARE-D from Astra Biocare." />
-  <title>ESOKARE-D - Astra Biocare</title>
-  <link rel="stylesheet" href="style.css" />
+  <meta name="description" content="Discover CLEAN-V3 from Astra Biocare." />
+  <title>CLEAN-V3 - Astra Biocare</title>
+  <link rel="stylesheet" href="../style.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
-  <script defer src="script.js"></script>
+  <script defer src="../script.js"></script>
   <script defer src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Product",
-      "name": "ESOKARE-D",
+      "name": "CLEAN-V3",
       "brand": "Astra Biocare",
-      "url": "https://www.astrabiocare.com/esokare-d.html"
+      "url": "https://www.astrabiocare.com/products/clean-v3.html"
     }
   </script>
 </head>
@@ -25,15 +25,15 @@
   <header class="site-header">
     <div class="container header-container">
       <div class="logo">
-        <img src="img/company_logo.png" alt="Astra Biocare Logo" />
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
         <h1>Astra Biocare</h1>
       </div>
       <nav>
         <ul class="nav-list">
-          <li><a href="index.html">Home</a></li>
+          <li><a href="../index.html">Home</a></li>
           <li><a href="products.html">Products</a></li>
-          <li><a href="about.html">About Us</a></li>
-          <li><a href="contact.html">Contact</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
         </ul>
       </nav>
       <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
@@ -43,13 +43,13 @@
   <main class="container">
     <section class="hero" data-aos="zoom-in">
       <div class="hero-text">
-        <h2>ESOKARE-D</h2>
-        <p>Digestive Support Formula</p>
+        <h2>CLEAN-V3</h2>
+        <p>Triple Action Cleanser</p>
         <a href="#request" class="btn-primary">Request Sample</a>
           <button class="share-btn" type="button">Share</button>
       </div>
       <div class="hero-img">
-        <img src="img/esokare-d.jpeg" alt="ESOKARE-D Product Image" />
+        <img src="../img/clean-v3.jpeg" alt="CLEAN-V3 Product Image" />
       </div>
     </section>
 

--- a/products/clean-v7.html
+++ b/products/clean-v7.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Discover CLEAN-V7 from Astra Biocare." />
   <title>CLEAN-V7 - Astra Biocare</title>
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="../style.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
-  <script defer src="script.js"></script>
+  <script defer src="../script.js"></script>
   <script defer src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
   <script type="application/ld+json">
@@ -17,7 +17,7 @@
       "@type": "Product",
       "name": "CLEAN-V7",
       "brand": "Astra Biocare",
-      "url": "https://www.astrabiocare.com/clean-v7.html"
+      "url": "https://www.astrabiocare.com/products/clean-v7.html"
     }
   </script>
 </head>
@@ -25,15 +25,15 @@
   <header class="site-header">
     <div class="container header-container">
       <div class="logo">
-        <img src="img/company_logo.png" alt="Astra Biocare Logo" />
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
         <h1>Astra Biocare</h1>
       </div>
       <nav>
         <ul class="nav-list">
-          <li><a href="index.html">Home</a></li>
+          <li><a href="../index.html">Home</a></li>
           <li><a href="products.html">Products</a></li>
-          <li><a href="about.html">About Us</a></li>
-          <li><a href="contact.html">Contact</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
         </ul>
       </nav>
       <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
@@ -49,7 +49,7 @@
           <button class="share-btn" type="button">Share</button>
       </div>
       <div class="hero-img">
-        <img src="img/clean-v7.jpeg" alt="CLEAN-V7 Product Image" />
+        <img src="../img/clean-v7.jpeg" alt="CLEAN-V7 Product Image" />
       </div>
     </section>
 

--- a/products/cycle-21.html
+++ b/products/cycle-21.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Discover SNORIL-D from Astra Biocare." />
-  <title>SNORIL-D - Astra Biocare</title>
-  <link rel="stylesheet" href="style.css" />
+  <meta name="description" content="Discover CYCLE-21 from Astra Biocare." />
+  <title>CYCLE-21 - Astra Biocare</title>
+  <link rel="stylesheet" href="../style.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
-  <script defer src="script.js"></script>
+  <script defer src="../script.js"></script>
   <script defer src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Product",
-      "name": "SNORIL-D",
+      "name": "CYCLE-21",
       "brand": "Astra Biocare",
-      "url": "https://www.astrabiocare.com/snoril-d.html"
+      "url": "https://www.astrabiocare.com/products/cycle-21.html"
     }
   </script>
 </head>
@@ -25,15 +25,15 @@
   <header class="site-header">
     <div class="container header-container">
       <div class="logo">
-        <img src="img/company_logo.png" alt="Astra Biocare Logo" />
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
         <h1>Astra Biocare</h1>
       </div>
       <nav>
         <ul class="nav-list">
-          <li><a href="index.html">Home</a></li>
+          <li><a href="../index.html">Home</a></li>
           <li><a href="products.html">Products</a></li>
-          <li><a href="about.html">About Us</a></li>
-          <li><a href="contact.html">Contact</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
         </ul>
       </nav>
       <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
@@ -43,13 +43,13 @@
   <main class="container">
     <section class="hero" data-aos="zoom-in">
       <div class="hero-text">
-        <h2>SNORIL-D</h2>
-        <p>Dual-Action Anti-Cold</p>
+        <h2>CYCLE-21</h2>
+        <p>Cycle Support Supplement</p>
         <a href="#request" class="btn-primary">Request Sample</a>
           <button class="share-btn" type="button">Share</button>
       </div>
       <div class="hero-img">
-        <img src="img/snoril-d.jpeg" alt="SNORIL-D Product Image" />
+        <img src="../img/cycle-21.jpeg" alt="CYCLE-21 Product Image" />
       </div>
     </section>
 

--- a/products/cystopil.html
+++ b/products/cystopil.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Discover D3-NINE from Astra Biocare." />
-  <title>D3-NINE - Astra Biocare</title>
-  <link rel="stylesheet" href="style.css" />
+  <meta name="description" content="Discover CYSTOPIL from Astra Biocare." />
+  <title>CYSTOPIL - Astra Biocare</title>
+  <link rel="stylesheet" href="../style.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
-  <script defer src="script.js"></script>
+  <script defer src="../script.js"></script>
   <script defer src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Product",
-      "name": "D3-NINE",
+      "name": "CYSTOPIL",
       "brand": "Astra Biocare",
-      "url": "https://www.astrabiocare.com/d3-nine.html"
+      "url": "https://www.astrabiocare.com/products/cystopil.html"
     }
   </script>
 </head>
@@ -25,15 +25,15 @@
   <header class="site-header">
     <div class="container header-container">
       <div class="logo">
-        <img src="img/company_logo.png" alt="Astra Biocare Logo" />
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
         <h1>Astra Biocare</h1>
       </div>
       <nav>
         <ul class="nav-list">
-          <li><a href="index.html">Home</a></li>
+          <li><a href="../index.html">Home</a></li>
           <li><a href="products.html">Products</a></li>
-          <li><a href="about.html">About Us</a></li>
-          <li><a href="contact.html">Contact</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
         </ul>
       </nav>
       <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
@@ -43,13 +43,13 @@
   <main class="container">
     <section class="hero" data-aos="zoom-in">
       <div class="hero-text">
-        <h2>D3-NINE</h2>
-        <p>Vitamin D3 High Absorption</p>
+        <h2>CYSTOPIL</h2>
+        <p>Urinary Health Support</p>
         <a href="#request" class="btn-primary">Request Sample</a>
           <button class="share-btn" type="button">Share</button>
       </div>
       <div class="hero-img">
-        <img src="img/d3-nine.jpeg" alt="D3-NINE Product Image" />
+        <img src="../img/cystopil.jpeg" alt="CYSTOPIL Product Image" />
       </div>
     </section>
 

--- a/products/d3-nine.html
+++ b/products/d3-nine.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Discover CYSTOPIL from Astra Biocare." />
-  <title>CYSTOPIL - Astra Biocare</title>
-  <link rel="stylesheet" href="style.css" />
+  <meta name="description" content="Discover D3-NINE from Astra Biocare." />
+  <title>D3-NINE - Astra Biocare</title>
+  <link rel="stylesheet" href="../style.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
-  <script defer src="script.js"></script>
+  <script defer src="../script.js"></script>
   <script defer src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Product",
-      "name": "CYSTOPIL",
+      "name": "D3-NINE",
       "brand": "Astra Biocare",
-      "url": "https://www.astrabiocare.com/cystopil.html"
+      "url": "https://www.astrabiocare.com/products/d3-nine.html"
     }
   </script>
 </head>
@@ -25,15 +25,15 @@
   <header class="site-header">
     <div class="container header-container">
       <div class="logo">
-        <img src="img/company_logo.png" alt="Astra Biocare Logo" />
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
         <h1>Astra Biocare</h1>
       </div>
       <nav>
         <ul class="nav-list">
-          <li><a href="index.html">Home</a></li>
+          <li><a href="../index.html">Home</a></li>
           <li><a href="products.html">Products</a></li>
-          <li><a href="about.html">About Us</a></li>
-          <li><a href="contact.html">Contact</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
         </ul>
       </nav>
       <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
@@ -43,13 +43,13 @@
   <main class="container">
     <section class="hero" data-aos="zoom-in">
       <div class="hero-text">
-        <h2>CYSTOPIL</h2>
-        <p>Urinary Health Support</p>
+        <h2>D3-NINE</h2>
+        <p>Vitamin D3 High Absorption</p>
         <a href="#request" class="btn-primary">Request Sample</a>
           <button class="share-btn" type="button">Share</button>
       </div>
       <div class="hero-img">
-        <img src="img/cystopil.jpeg" alt="CYSTOPIL Product Image" />
+        <img src="../img/d3-nine.jpeg" alt="D3-NINE Product Image" />
       </div>
     </section>
 

--- a/products/esokare-d.html
+++ b/products/esokare-d.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Discover CLEAN-V3 from Astra Biocare." />
-  <title>CLEAN-V3 - Astra Biocare</title>
-  <link rel="stylesheet" href="style.css" />
+  <meta name="description" content="Discover ESOKARE-D from Astra Biocare." />
+  <title>ESOKARE-D - Astra Biocare</title>
+  <link rel="stylesheet" href="../style.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
-  <script defer src="script.js"></script>
+  <script defer src="../script.js"></script>
   <script defer src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Product",
-      "name": "CLEAN-V3",
+      "name": "ESOKARE-D",
       "brand": "Astra Biocare",
-      "url": "https://www.astrabiocare.com/clean-v3.html"
+      "url": "https://www.astrabiocare.com/products/esokare-d.html"
     }
   </script>
 </head>
@@ -25,15 +25,15 @@
   <header class="site-header">
     <div class="container header-container">
       <div class="logo">
-        <img src="img/company_logo.png" alt="Astra Biocare Logo" />
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
         <h1>Astra Biocare</h1>
       </div>
       <nav>
         <ul class="nav-list">
-          <li><a href="index.html">Home</a></li>
+          <li><a href="../index.html">Home</a></li>
           <li><a href="products.html">Products</a></li>
-          <li><a href="about.html">About Us</a></li>
-          <li><a href="contact.html">Contact</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
         </ul>
       </nav>
       <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
@@ -43,13 +43,13 @@
   <main class="container">
     <section class="hero" data-aos="zoom-in">
       <div class="hero-text">
-        <h2>CLEAN-V3</h2>
-        <p>Triple Action Cleanser</p>
+        <h2>ESOKARE-D</h2>
+        <p>Digestive Support Formula</p>
         <a href="#request" class="btn-primary">Request Sample</a>
           <button class="share-btn" type="button">Share</button>
       </div>
       <div class="hero-img">
-        <img src="img/clean-v3.jpeg" alt="CLEAN-V3 Product Image" />
+        <img src="../img/esokare-d.jpeg" alt="ESOKARE-D Product Image" />
       </div>
     </section>
 

--- a/products/foljoy.html
+++ b/products/foljoy.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Discover CYCLE-21 from Astra Biocare." />
-  <title>CYCLE-21 - Astra Biocare</title>
-  <link rel="stylesheet" href="style.css" />
+  <meta name="description" content="Discover FOLJOY from Astra Biocare." />
+  <title>FOLJOY - Astra Biocare</title>
+  <link rel="stylesheet" href="../style.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
-  <script defer src="script.js"></script>
+  <script defer src="../script.js"></script>
   <script defer src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Product",
-      "name": "CYCLE-21",
+      "name": "FOLJOY",
       "brand": "Astra Biocare",
-      "url": "https://www.astrabiocare.com/cycle-21.html"
+      "url": "https://www.astrabiocare.com/products/foljoy.html"
     }
   </script>
 </head>
@@ -25,15 +25,15 @@
   <header class="site-header">
     <div class="container header-container">
       <div class="logo">
-        <img src="img/company_logo.png" alt="Astra Biocare Logo" />
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
         <h1>Astra Biocare</h1>
       </div>
       <nav>
         <ul class="nav-list">
-          <li><a href="index.html">Home</a></li>
+          <li><a href="../index.html">Home</a></li>
           <li><a href="products.html">Products</a></li>
-          <li><a href="about.html">About Us</a></li>
-          <li><a href="contact.html">Contact</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
         </ul>
       </nav>
       <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
@@ -43,13 +43,13 @@
   <main class="container">
     <section class="hero" data-aos="zoom-in">
       <div class="hero-text">
-        <h2>CYCLE-21</h2>
-        <p>Cycle Support Supplement</p>
+        <h2>FOLJOY</h2>
+        <p>Next Generation Active Folate</p>
         <a href="#request" class="btn-primary">Request Sample</a>
           <button class="share-btn" type="button">Share</button>
       </div>
       <div class="hero-img">
-        <img src="img/cycle-21.jpeg" alt="CYCLE-21 Product Image" />
+        <img src="../img/foljoy.jpeg" alt="FOLJOY Product Image" />
       </div>
     </section>
 

--- a/products/products.html
+++ b/products/products.html
@@ -4,23 +4,23 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Astra Biocare Pvt Ltd - Products</title>
-  <link rel="stylesheet" href="style.css" />
-  <script defer src="script.js"></script>
+  <link rel="stylesheet" href="../style.css" />
+  <script defer src="../script.js"></script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
 <body>
   <header class="site-header">
     <div class="container header-container">
       <div class="logo">
-        <img src="img/company_logo.png" alt="Astra Biocare Logo" />
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
         <h1>Astra Biocare</h1>
       </div>
       <nav>
         <ul class="nav-list">
-          <li><a href="index.html">Home</a></li>
+          <li><a href="../index.html">Home</a></li>
           <li><a href="products.html">Products</a></li>
-          <li><a href="about.html">About Us</a></li>
-          <li><a href="contact.html">Contact</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
         </ul>
       </nav>
       <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
@@ -31,16 +31,16 @@
     <section>
       <h2>Our Products</h2>
       <div class="product-grid">
-        <a class="product-card" href="foljoy.html"><img src="img/foljoy.jpeg" alt="FOLJOY"><h3>FOLJOY</h3></a>
-        <a class="product-card" href="clean-v7.html"><img src="img/clean-v7.jpeg" alt="CLEAN-V7"><h3>CLEAN-V7</h3></a>
-        <a class="product-card" href="clean-v3.html"><img src="img/clean-v3.jpeg" alt="CLEAN-V3"><h3>CLEAN-V3</h3></a>
-        <a class="product-card" href="cycle-21.html"><img src="img/cycle-21.jpeg" alt="CYCLE-21"><h3>CYCLE-21</h3></a>
-        <a class="product-card" href="cystopil.html"><img src="img/cystopil.jpeg" alt="CYSTOPIL"><h3>CYSTOPIL</h3></a>
-        <a class="product-card" href="esokare-d.html"><img src="img/esokare-d.jpeg" alt="ESOKARE-D"><h3>ESOKARE-D</h3></a>
-        <a class="product-card" href="snoril-lx.html"><img src="img/snoril-lx.jpeg" alt="SNORIL-LX"><h3>SNORIL-LX</h3></a>
-        <a class="product-card" href="snoril-d.html"><img src="img/snoril-d.jpeg" alt="SNORIL-D"><h3>SNORIL-D</h3></a>
-        <a class="product-card" href="vitotop.html"><img src="img/vitotop.jpeg" alt="VITOTOP"><h3>VITOTOP</h3></a>
-        <a class="product-card" href="d3-nine.html"><img src="img/d3-nine.jpeg" alt="D3-NINE"><h3>D3-NINE</h3></a>
+        <a class="product-card" href="foljoy.html"><img src="../img/foljoy.jpeg" alt="FOLJOY"><h3>FOLJOY</h3></a>
+        <a class="product-card" href="clean-v7.html"><img src="../img/clean-v7.jpeg" alt="CLEAN-V7"><h3>CLEAN-V7</h3></a>
+        <a class="product-card" href="clean-v3.html"><img src="../img/clean-v3.jpeg" alt="CLEAN-V3"><h3>CLEAN-V3</h3></a>
+        <a class="product-card" href="cycle-21.html"><img src="../img/cycle-21.jpeg" alt="CYCLE-21"><h3>CYCLE-21</h3></a>
+        <a class="product-card" href="cystopil.html"><img src="../img/cystopil.jpeg" alt="CYSTOPIL"><h3>CYSTOPIL</h3></a>
+        <a class="product-card" href="esokare-d.html"><img src="../img/esokare-d.jpeg" alt="ESOKARE-D"><h3>ESOKARE-D</h3></a>
+        <a class="product-card" href="snoril-lx.html"><img src="../img/snoril-lx.jpeg" alt="SNORIL-LX"><h3>SNORIL-LX</h3></a>
+        <a class="product-card" href="snoril-d.html"><img src="../img/snoril-d.jpeg" alt="SNORIL-D"><h3>SNORIL-D</h3></a>
+        <a class="product-card" href="vitotop.html"><img src="../img/vitotop.jpeg" alt="VITOTOP"><h3>VITOTOP</h3></a>
+        <a class="product-card" href="d3-nine.html"><img src="../img/d3-nine.jpeg" alt="D3-NINE"><h3>D3-NINE</h3></a>
       </div>
     </section>
   </main>

--- a/products/snoril-d.html
+++ b/products/snoril-d.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Discover SNORIL-LX from Astra Biocare." />
-  <title>SNORIL-LX - Astra Biocare</title>
-  <link rel="stylesheet" href="style.css" />
+  <meta name="description" content="Discover SNORIL-D from Astra Biocare." />
+  <title>SNORIL-D - Astra Biocare</title>
+  <link rel="stylesheet" href="../style.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
-  <script defer src="script.js"></script>
+  <script defer src="../script.js"></script>
   <script defer src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Product",
-      "name": "SNORIL-LX",
+      "name": "SNORIL-D",
       "brand": "Astra Biocare",
-      "url": "https://www.astrabiocare.com/snoril-lx.html"
+      "url": "https://www.astrabiocare.com/products/snoril-d.html"
     }
   </script>
 </head>
@@ -25,15 +25,15 @@
   <header class="site-header">
     <div class="container header-container">
       <div class="logo">
-        <img src="img/company_logo.png" alt="Astra Biocare Logo" />
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
         <h1>Astra Biocare</h1>
       </div>
       <nav>
         <ul class="nav-list">
-          <li><a href="index.html">Home</a></li>
+          <li><a href="../index.html">Home</a></li>
           <li><a href="products.html">Products</a></li>
-          <li><a href="about.html">About Us</a></li>
-          <li><a href="contact.html">Contact</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
         </ul>
       </nav>
       <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
@@ -43,13 +43,13 @@
   <main class="container">
     <section class="hero" data-aos="zoom-in">
       <div class="hero-text">
-        <h2>SNORIL-LX</h2>
-        <p>Non-Drowsy Nasal Support</p>
+        <h2>SNORIL-D</h2>
+        <p>Dual-Action Anti-Cold</p>
         <a href="#request" class="btn-primary">Request Sample</a>
           <button class="share-btn" type="button">Share</button>
       </div>
       <div class="hero-img">
-        <img src="img/snoril-lx.jpeg" alt="SNORIL-LX Product Image" />
+        <img src="../img/snoril-d.jpeg" alt="SNORIL-D Product Image" />
       </div>
     </section>
 

--- a/products/snoril-lx.html
+++ b/products/snoril-lx.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Discover VITOTOP from Astra Biocare." />
-  <title>VITOTOP - Astra Biocare</title>
-  <link rel="stylesheet" href="style.css" />
+  <meta name="description" content="Discover SNORIL-LX from Astra Biocare." />
+  <title>SNORIL-LX - Astra Biocare</title>
+  <link rel="stylesheet" href="../style.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
-  <script defer src="script.js"></script>
+  <script defer src="../script.js"></script>
   <script defer src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Product",
-      "name": "VITOTOP",
+      "name": "SNORIL-LX",
       "brand": "Astra Biocare",
-      "url": "https://www.astrabiocare.com/vitotop.html"
+      "url": "https://www.astrabiocare.com/products/snoril-lx.html"
     }
   </script>
 </head>
@@ -25,15 +25,15 @@
   <header class="site-header">
     <div class="container header-container">
       <div class="logo">
-        <img src="img/company_logo.png" alt="Astra Biocare Logo" />
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
         <h1>Astra Biocare</h1>
       </div>
       <nav>
         <ul class="nav-list">
-          <li><a href="index.html">Home</a></li>
+          <li><a href="../index.html">Home</a></li>
           <li><a href="products.html">Products</a></li>
-          <li><a href="about.html">About Us</a></li>
-          <li><a href="contact.html">Contact</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
         </ul>
       </nav>
       <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
@@ -43,13 +43,13 @@
   <main class="container">
     <section class="hero" data-aos="zoom-in">
       <div class="hero-text">
-        <h2>VITOTOP</h2>
-        <p>Multivitamin with Immunity Boost</p>
+        <h2>SNORIL-LX</h2>
+        <p>Non-Drowsy Nasal Support</p>
         <a href="#request" class="btn-primary">Request Sample</a>
           <button class="share-btn" type="button">Share</button>
       </div>
       <div class="hero-img">
-        <img src="img/vitotop.jpeg" alt="VITOTOP Product Image" />
+        <img src="../img/snoril-lx.jpeg" alt="SNORIL-LX Product Image" />
       </div>
     </section>
 

--- a/products/vitotop.html
+++ b/products/vitotop.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Discover FOLJOY from Astra Biocare." />
-  <title>FOLJOY - Astra Biocare</title>
-  <link rel="stylesheet" href="style.css" />
+  <meta name="description" content="Discover VITOTOP from Astra Biocare." />
+  <title>VITOTOP - Astra Biocare</title>
+  <link rel="stylesheet" href="../style.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
-  <script defer src="script.js"></script>
+  <script defer src="../script.js"></script>
   <script defer src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
   <script>AOS.init();</script>
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Product",
-      "name": "FOLJOY",
+      "name": "VITOTOP",
       "brand": "Astra Biocare",
-      "url": "https://www.astrabiocare.com/foljoy.html"
+      "url": "https://www.astrabiocare.com/products/vitotop.html"
     }
   </script>
 </head>
@@ -25,15 +25,15 @@
   <header class="site-header">
     <div class="container header-container">
       <div class="logo">
-        <img src="img/company_logo.png" alt="Astra Biocare Logo" />
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
         <h1>Astra Biocare</h1>
       </div>
       <nav>
         <ul class="nav-list">
-          <li><a href="index.html">Home</a></li>
+          <li><a href="../index.html">Home</a></li>
           <li><a href="products.html">Products</a></li>
-          <li><a href="about.html">About Us</a></li>
-          <li><a href="contact.html">Contact</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
         </ul>
       </nav>
       <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
@@ -43,13 +43,13 @@
   <main class="container">
     <section class="hero" data-aos="zoom-in">
       <div class="hero-text">
-        <h2>FOLJOY</h2>
-        <p>Next Generation Active Folate</p>
+        <h2>VITOTOP</h2>
+        <p>Multivitamin with Immunity Boost</p>
         <a href="#request" class="btn-primary">Request Sample</a>
           <button class="share-btn" type="button">Share</button>
       </div>
       <div class="hero-img">
-        <img src="img/foljoy.jpeg" alt="FOLJOY Product Image" />
+        <img src="../img/vitotop.jpeg" alt="VITOTOP Product Image" />
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- organize HTML files by moving product pages into `products/`
- update navigation links to new paths
- adjust asset paths and canonical URLs in moved pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686e0a25dadc8330b883b3ce955854ad