### PR TITLE
Add missing product pages

### DIFF
--- a/products/astraclav.html
+++ b/products/astraclav.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Discover ASTRACLAV from Astra Biocare." />
+  <title>ASTRACLAV - Astra Biocare</title>
+  <link rel="stylesheet" href="../style.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
+  <script defer src="../script.js"></script>
+  <script defer src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
+  <script>AOS.init();</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "ASTRACLAV",
+      "brand": "Astra Biocare",
+      "url": "https://www.astrabiocare.com/products/astraclav.html"
+    }
+  </script>
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-container">
+      <div class="logo">
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
+        <h1>Astra Biocare</h1>
+      </div>
+      <nav>
+        <ul class="nav-list">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="products.html">Products</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="hero" data-aos="zoom-in">
+      <div class="hero-text">
+        <h2>ASTRACLAV</h2>
+        <p>Powerful Antibiotic Therapy</p>
+        <a href="#request" class="btn-primary">Request Sample</a>
+          <button class="share-btn" type="button">Share</button>
+      </div>
+      <div class="hero-img">
+        <img src="../img/astraclav.jpeg" alt="ASTRACLAV Product Image" />
+      </div>
+    </section>
+
+    <section data-aos="fade-up">
+      <h3>Product Description</h3>
+      <p>This is a high-quality pharmaceutical product designed to meet modern healthcare needs.</p>
+    </section>
+
+    <section data-aos="fade-right">
+      <h3>Usage Instructions</h3>
+      <ul>
+        <li>Use as directed by a healthcare professional.</li>
+        <li>Store in a cool, dry place.</li>
+        <li>Keep out of reach of children.</li>
+      </ul>
+    </section>
+
+    <section id="request" data-aos="fade-up">
+      <h3>Request a Sample</h3>
+      <form action="https://formspree.io/f/your-id-here" method="POST">
+        <label for="name">Name:</label>
+        <input id="name" type="text" name="name" required />
+
+        <label for="email">Email:</label>
+        <input id="email" type="email" name="email" required />
+
+        <label for="message">Message:</label>
+        <textarea id="message" name="message" rows="4" placeholder="Your request..." required></textarea>
+
+        <input type="submit" value="Send Request" />
+      </form>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>&copy; 2025 Astra Biocare Pvt Ltd. All rights reserved.</p>
+      <address>
+        Registered Office: #16, 2nd cross, Aruna Building, Somasundrapalya, Bangalore, Karnataka - 560102.
+      </address>
+      <ul class="social-links">
+        <li><a href="https://www.facebook.com/astrabiocare/" target="_blank" aria-label="Facebook"><i class="fab fa-facebook-f"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="Twitter"><i class="fab fa-twitter"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="Instagram"><i class="fab fa-instagram"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="LinkedIn"><i class="fab fa-linkedin-in"></i></a></li>
+      </ul>
+    </div>
+  </footer>
+</body>
+</html>

--- a/products/megamont-l.html
+++ b/products/megamont-l.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Discover MEGAMONT-L from Astra Biocare." />
+  <title>MEGAMONT-L - Astra Biocare</title>
+  <link rel="stylesheet" href="../style.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
+  <script defer src="../script.js"></script>
+  <script defer src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
+  <script>AOS.init();</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "MEGAMONT-L",
+      "brand": "Astra Biocare",
+      "url": "https://www.astrabiocare.com/products/megamont-l.html"
+    }
+  </script>
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-container">
+      <div class="logo">
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
+        <h1>Astra Biocare</h1>
+      </div>
+      <nav>
+        <ul class="nav-list">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="products.html">Products</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="hero" data-aos="zoom-in">
+      <div class="hero-text">
+        <h2>MEGAMONT-L</h2>
+        <p>Allergy Symptom Relief</p>
+        <a href="#request" class="btn-primary">Request Sample</a>
+          <button class="share-btn" type="button">Share</button>
+      </div>
+      <div class="hero-img">
+        <img src="../img/megamont-l.jpeg" alt="MEGAMONT-L Product Image" />
+      </div>
+    </section>
+
+    <section data-aos="fade-up">
+      <h3>Product Description</h3>
+      <p>This is a high-quality pharmaceutical product designed to meet modern healthcare needs.</p>
+    </section>
+
+    <section data-aos="fade-right">
+      <h3>Usage Instructions</h3>
+      <ul>
+        <li>Use as directed by a healthcare professional.</li>
+        <li>Store in a cool, dry place.</li>
+        <li>Keep out of reach of children.</li>
+      </ul>
+    </section>
+
+    <section id="request" data-aos="fade-up">
+      <h3>Request a Sample</h3>
+      <form action="https://formspree.io/f/your-id-here" method="POST">
+        <label for="name">Name:</label>
+        <input id="name" type="text" name="name" required />
+
+        <label for="email">Email:</label>
+        <input id="email" type="email" name="email" required />
+
+        <label for="message">Message:</label>
+        <textarea id="message" name="message" rows="4" placeholder="Your request..." required></textarea>
+
+        <input type="submit" value="Send Request" />
+      </form>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>&copy; 2025 Astra Biocare Pvt Ltd. All rights reserved.</p>
+      <address>
+        Registered Office: #16, 2nd cross, Aruna Building, Somasundrapalya, Bangalore, Karnataka - 560102.
+      </address>
+      <ul class="social-links">
+        <li><a href="https://www.facebook.com/astrabiocare/" target="_blank" aria-label="Facebook"><i class="fab fa-facebook-f"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="Twitter"><i class="fab fa-twitter"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="Instagram"><i class="fab fa-instagram"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="LinkedIn"><i class="fab fa-linkedin-in"></i></a></li>
+      </ul>
+    </div>
+  </footer>
+</body>
+</html>

--- a/products/rightcef.html
+++ b/products/rightcef.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Discover RIGHTCEF from Astra Biocare." />
+  <title>RIGHTCEF - Astra Biocare</title>
+  <link rel="stylesheet" href="../style.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
+  <script defer src="../script.js"></script>
+  <script defer src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
+  <script>AOS.init();</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "RIGHTCEF",
+      "brand": "Astra Biocare",
+      "url": "https://www.astrabiocare.com/products/rightcef.html"
+    }
+  </script>
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-container">
+      <div class="logo">
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
+        <h1>Astra Biocare</h1>
+      </div>
+      <nav>
+        <ul class="nav-list">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="products.html">Products</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="hero" data-aos="zoom-in">
+      <div class="hero-text">
+        <h2>RIGHTCEF</h2>
+        <p>Broad-Spectrum Antibiotic</p>
+        <a href="#request" class="btn-primary">Request Sample</a>
+          <button class="share-btn" type="button">Share</button>
+      </div>
+      <div class="hero-img">
+        <img src="../img/rightcef.jpeg" alt="RIGHTCEF Product Image" />
+      </div>
+    </section>
+
+    <section data-aos="fade-up">
+      <h3>Product Description</h3>
+      <p>This is a high-quality pharmaceutical product designed to meet modern healthcare needs.</p>
+    </section>
+
+    <section data-aos="fade-right">
+      <h3>Usage Instructions</h3>
+      <ul>
+        <li>Use as directed by a healthcare professional.</li>
+        <li>Store in a cool, dry place.</li>
+        <li>Keep out of reach of children.</li>
+      </ul>
+    </section>
+
+    <section id="request" data-aos="fade-up">
+      <h3>Request a Sample</h3>
+      <form action="https://formspree.io/f/your-id-here" method="POST">
+        <label for="name">Name:</label>
+        <input id="name" type="text" name="name" required />
+
+        <label for="email">Email:</label>
+        <input id="email" type="email" name="email" required />
+
+        <label for="message">Message:</label>
+        <textarea id="message" name="message" rows="4" placeholder="Your request..." required></textarea>
+
+        <input type="submit" value="Send Request" />
+      </form>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>&copy; 2025 Astra Biocare Pvt Ltd. All rights reserved.</p>
+      <address>
+        Registered Office: #16, 2nd cross, Aruna Building, Somasundrapalya, Bangalore, Karnataka - 560102.
+      </address>
+      <ul class="social-links">
+        <li><a href="https://www.facebook.com/astrabiocare/" target="_blank" aria-label="Facebook"><i class="fab fa-facebook-f"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="Twitter"><i class="fab fa-twitter"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="Instagram"><i class="fab fa-instagram"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="LinkedIn"><i class="fab fa-linkedin-in"></i></a></li>
+      </ul>
+    </div>
+  </footer>
+</body>
+</html>

--- a/products/setmol-mds.html
+++ b/products/setmol-mds.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Discover SETMOL-MDS from Astra Biocare." />
+  <title>SETMOL-MDS - Astra Biocare</title>
+  <link rel="stylesheet" href="../style.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
+  <script defer src="../script.js"></script>
+  <script defer src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
+  <script>AOS.init();</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "SETMOL-MDS",
+      "brand": "Astra Biocare",
+      "url": "https://www.astrabiocare.com/products/setmol-mds.html"
+    }
+  </script>
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-container">
+      <div class="logo">
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
+        <h1>Astra Biocare</h1>
+      </div>
+      <nav>
+        <ul class="nav-list">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="products.html">Products</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="hero" data-aos="zoom-in">
+      <div class="hero-text">
+        <h2>SETMOL-MDS</h2>
+        <p>Rapid Pain Relief</p>
+        <a href="#request" class="btn-primary">Request Sample</a>
+          <button class="share-btn" type="button">Share</button>
+      </div>
+      <div class="hero-img">
+        <img src="../img/setmol-mds.jpeg" alt="SETMOL-MDS Product Image" />
+      </div>
+    </section>
+
+    <section data-aos="fade-up">
+      <h3>Product Description</h3>
+      <p>This is a high-quality pharmaceutical product designed to meet modern healthcare needs.</p>
+    </section>
+
+    <section data-aos="fade-right">
+      <h3>Usage Instructions</h3>
+      <ul>
+        <li>Use as directed by a healthcare professional.</li>
+        <li>Store in a cool, dry place.</li>
+        <li>Keep out of reach of children.</li>
+      </ul>
+    </section>
+
+    <section id="request" data-aos="fade-up">
+      <h3>Request a Sample</h3>
+      <form action="https://formspree.io/f/your-id-here" method="POST">
+        <label for="name">Name:</label>
+        <input id="name" type="text" name="name" required />
+
+        <label for="email">Email:</label>
+        <input id="email" type="email" name="email" required />
+
+        <label for="message">Message:</label>
+        <textarea id="message" name="message" rows="4" placeholder="Your request..." required></textarea>
+
+        <input type="submit" value="Send Request" />
+      </form>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>&copy; 2025 Astra Biocare Pvt Ltd. All rights reserved.</p>
+      <address>
+        Registered Office: #16, 2nd cross, Aruna Building, Somasundrapalya, Bangalore, Karnataka - 560102.
+      </address>
+      <ul class="social-links">
+        <li><a href="https://www.facebook.com/astrabiocare/" target="_blank" aria-label="Facebook"><i class="fab fa-facebook-f"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="Twitter"><i class="fab fa-twitter"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="Instagram"><i class="fab fa-instagram"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="LinkedIn"><i class="fab fa-linkedin-in"></i></a></li>
+      </ul>
+    </div>
+  </footer>
+</body>
+</html>

--- a/products/super-hb.html
+++ b/products/super-hb.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Discover SUPER-HB from Astra Biocare." />
+  <title>SUPER-HB - Astra Biocare</title>
+  <link rel="stylesheet" href="../style.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
+  <script defer src="../script.js"></script>
+  <script defer src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
+  <script>AOS.init();</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "SUPER-HB",
+      "brand": "Astra Biocare",
+      "url": "https://www.astrabiocare.com/products/super-hb.html"
+    }
+  </script>
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-container">
+      <div class="logo">
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
+        <h1>Astra Biocare</h1>
+      </div>
+      <nav>
+        <ul class="nav-list">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="products.html">Products</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="hero" data-aos="zoom-in">
+      <div class="hero-text">
+        <h2>SUPER-HB</h2>
+        <p>Comprehensive Iron Booster</p>
+        <a href="#request" class="btn-primary">Request Sample</a>
+          <button class="share-btn" type="button">Share</button>
+      </div>
+      <div class="hero-img">
+        <img src="../img/super-hb.JPG" alt="SUPER-HB Product Image" />
+      </div>
+    </section>
+
+    <section data-aos="fade-up">
+      <h3>Product Description</h3>
+      <p>This is a high-quality pharmaceutical product designed to meet modern healthcare needs.</p>
+    </section>
+
+    <section data-aos="fade-right">
+      <h3>Usage Instructions</h3>
+      <ul>
+        <li>Use as directed by a healthcare professional.</li>
+        <li>Store in a cool, dry place.</li>
+        <li>Keep out of reach of children.</li>
+      </ul>
+    </section>
+
+    <section id="request" data-aos="fade-up">
+      <h3>Request a Sample</h3>
+      <form action="https://formspree.io/f/your-id-here" method="POST">
+        <label for="name">Name:</label>
+        <input id="name" type="text" name="name" required />
+
+        <label for="email">Email:</label>
+        <input id="email" type="email" name="email" required />
+
+        <label for="message">Message:</label>
+        <textarea id="message" name="message" rows="4" placeholder="Your request..." required></textarea>
+
+        <input type="submit" value="Send Request" />
+      </form>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>&copy; 2025 Astra Biocare Pvt Ltd. All rights reserved.</p>
+      <address>
+        Registered Office: #16, 2nd cross, Aruna Building, Somasundrapalya, Bangalore, Karnataka - 560102.
+      </address>
+      <ul class="social-links">
+        <li><a href="https://www.facebook.com/astrabiocare/" target="_blank" aria-label="Facebook"><i class="fab fa-facebook-f"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="Twitter"><i class="fab fa-twitter"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="Instagram"><i class="fab fa-instagram"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="LinkedIn"><i class="fab fa-linkedin-in"></i></a></li>
+      </ul>
+    </div>
+  </footer>
+</body>
+</html>

--- a/products/supergest.html
+++ b/products/supergest.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Discover SUPERGEST-SR from Astra Biocare." />
+  <title>SUPERGEST-SR - Astra Biocare</title>
+  <link rel="stylesheet" href="../style.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
+  <script defer src="../script.js"></script>
+  <script defer src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
+  <script>AOS.init();</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "SUPERGEST-SR",
+      "brand": "Astra Biocare",
+      "url": "https://www.astrabiocare.com/products/supergest.html"
+    }
+  </script>
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-container">
+      <div class="logo">
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
+        <h1>Astra Biocare</h1>
+      </div>
+      <nav>
+        <ul class="nav-list">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="products.html">Products</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="hero" data-aos="zoom-in">
+      <div class="hero-text">
+        <h2>SUPERGEST-SR</h2>
+        <p>Digestive Enzyme Support</p>
+        <a href="#request" class="btn-primary">Request Sample</a>
+          <button class="share-btn" type="button">Share</button>
+      </div>
+      <div class="hero-img">
+        <img src="../img/supergest-sr.jpg" alt="SUPERGEST-SR Product Image" />
+      </div>
+    </section>
+
+    <section data-aos="fade-up">
+      <h3>Product Description</h3>
+      <p>This is a high-quality pharmaceutical product designed to meet modern healthcare needs.</p>
+    </section>
+
+    <section data-aos="fade-right">
+      <h3>Usage Instructions</h3>
+      <ul>
+        <li>Use as directed by a healthcare professional.</li>
+        <li>Store in a cool, dry place.</li>
+        <li>Keep out of reach of children.</li>
+      </ul>
+    </section>
+
+    <section id="request" data-aos="fade-up">
+      <h3>Request a Sample</h3>
+      <form action="https://formspree.io/f/your-id-here" method="POST">
+        <label for="name">Name:</label>
+        <input id="name" type="text" name="name" required />
+
+        <label for="email">Email:</label>
+        <input id="email" type="email" name="email" required />
+
+        <label for="message">Message:</label>
+        <textarea id="message" name="message" rows="4" placeholder="Your request..." required></textarea>
+
+        <input type="submit" value="Send Request" />
+      </form>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>&copy; 2025 Astra Biocare Pvt Ltd. All rights reserved.</p>
+      <address>
+        Registered Office: #16, 2nd cross, Aruna Building, Somasundrapalya, Bangalore, Karnataka - 560102.
+      </address>
+      <ul class="social-links">
+        <li><a href="https://www.facebook.com/astrabiocare/" target="_blank" aria-label="Facebook"><i class="fab fa-facebook-f"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="Twitter"><i class="fab fa-twitter"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="Instagram"><i class="fab fa-instagram"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="LinkedIn"><i class="fab fa-linkedin-in"></i></a></li>
+      </ul>
+    </div>
+  </footer>
+</body>
+</html>

--- a/products/z-on.html
+++ b/products/z-on.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Discover Z-ON from Astra Biocare." />
+  <title>Z-ON - Astra Biocare</title>
+  <link rel="stylesheet" href="../style.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p+1JxS8EU1RcUnnqgKTTDYXYBvCZUc5JSpSXZLF645xvLZHbiRL+CRceZ9UnB9Z9GjK6xwHy3v4sHtQ+Dx2Y/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
+  <script defer src="../script.js"></script>
+  <script defer src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
+  <script>AOS.init();</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "Z-ON",
+      "brand": "Astra Biocare",
+      "url": "https://www.astrabiocare.com/products/z-on.html"
+    }
+  </script>
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-container">
+      <div class="logo">
+        <img src="../img/company_logo.png" alt="Astra Biocare Logo" />
+        <h1>Astra Biocare</h1>
+      </div>
+      <nav>
+        <ul class="nav-list">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="products.html">Products</a></li>
+          <li><a href="../about.html">About Us</a></li>
+          <li><a href="../contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <button id="themeBtn" aria-label="Toggle dark mode" title="Toggle dark mode">🌓</button>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="hero" data-aos="zoom-in">
+      <div class="hero-text">
+        <h2>Z-ON</h2>
+        <p>Essential Zinc Formula</p>
+        <a href="#request" class="btn-primary">Request Sample</a>
+          <button class="share-btn" type="button">Share</button>
+      </div>
+      <div class="hero-img">
+        <img src="../img/z-on.jpeg" alt="Z-ON Product Image" />
+      </div>
+    </section>
+
+    <section data-aos="fade-up">
+      <h3>Product Description</h3>
+      <p>This is a high-quality pharmaceutical product designed to meet modern healthcare needs.</p>
+    </section>
+
+    <section data-aos="fade-right">
+      <h3>Usage Instructions</h3>
+      <ul>
+        <li>Use as directed by a healthcare professional.</li>
+        <li>Store in a cool, dry place.</li>
+        <li>Keep out of reach of children.</li>
+      </ul>
+    </section>
+
+    <section id="request" data-aos="fade-up">
+      <h3>Request a Sample</h3>
+      <form action="https://formspree.io/f/your-id-here" method="POST">
+        <label for="name">Name:</label>
+        <input id="name" type="text" name="name" required />
+
+        <label for="email">Email:</label>
+        <input id="email" type="email" name="email" required />
+
+        <label for="message">Message:</label>
+        <textarea id="message" name="message" rows="4" placeholder="Your request..." required></textarea>
+
+        <input type="submit" value="Send Request" />
+      </form>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>&copy; 2025 Astra Biocare Pvt Ltd. All rights reserved.</p>
+      <address>
+        Registered Office: #16, 2nd cross, Aruna Building, Somasundrapalya, Bangalore, Karnataka - 560102.
+      </address>
+      <ul class="social-links">
+        <li><a href="https://www.facebook.com/astrabiocare/" target="_blank" aria-label="Facebook"><i class="fab fa-facebook-f"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="Twitter"><i class="fab fa-twitter"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="Instagram"><i class="fab fa-instagram"></i></a></li>
+        <li><a href="#" target="_blank" aria-label="LinkedIn"><i class="fab fa-linkedin-in"></i></a></li>
+      </ul>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add HTML pages for Supergest-SR, Super-HB, Z-ON, Astraclav, Rightcef, Setmol-MDS and Megamont-L
- each page is based on `clean-v3.html` with updated product name, hero tagline, image path and schema data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687673e7756c83309876c6826427e790