### PR TITLE
Improve contact form handling and add baseline security headers

### DIFF
--- a/next-app/next.config.ts
+++ b/next-app/next.config.ts
@@ -1,7 +1,22 @@
 import type { NextConfig } from "next";
 
+const securityHeaders = [
+  { key: "X-Frame-Options", value: "SAMEORIGIN" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+  { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains; preload" },
+];
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/next-app/src/app/api/contact/route.ts
+++ b/next-app/src/app/api/contact/route.ts
@@ -1,7 +1,37 @@
 import { NextResponse } from 'next/server';
 
+const MAX_MESSAGE_LENGTH = 2000;
+
+type ContactPayload = {
+  name?: string;
+  email?: string;
+  phone?: string;
+  company?: string;
+  message?: string;
+  companyWebsite?: string;
+};
+
+function isNonEmpty(value?: string) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
 export async function POST(request: Request) {
-  const data = await request.json();
-  console.log('Contact enquiry', data);
+  const data = (await request.json().catch(() => null)) as ContactPayload | null;
+  if (!data) {
+    return NextResponse.json({ ok: false, error: 'Invalid payload.' }, { status: 400 });
+  }
+
+  if (isNonEmpty(data.companyWebsite)) {
+    return NextResponse.json({ ok: true });
+  }
+
+  if (!isNonEmpty(data.name) || !isNonEmpty(data.email) || !isNonEmpty(data.message)) {
+    return NextResponse.json({ ok: false, error: 'Missing required fields.' }, { status: 400 });
+  }
+
+  if (data.message && data.message.length > MAX_MESSAGE_LENGTH) {
+    return NextResponse.json({ ok: false, error: 'Message too long.' }, { status: 400 });
+  }
+
   return NextResponse.json({ ok: true });
 }

--- a/next-app/src/app/contact/page.tsx
+++ b/next-app/src/app/contact/page.tsx
@@ -4,16 +4,29 @@ import { FormEvent, useState } from 'react';
 
 export default function Contact() {
   const [submitted, setSubmitted] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    setIsSubmitting(true);
+    setErrorMessage('');
     const formData = new FormData(e.currentTarget);
-    await fetch('/api/contact', {
-      method: 'POST',
-      body: JSON.stringify(Object.fromEntries(formData)),
-      headers: { 'Content-Type': 'application/json' },
-    });
-    setSubmitted(true);
+    try {
+      const response = await fetch('/api/contact', {
+        method: 'POST',
+        body: JSON.stringify(Object.fromEntries(formData)),
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!response.ok) {
+        throw new Error('Submission failed');
+      }
+      setSubmitted(true);
+    } catch (error) {
+      setErrorMessage('We could not send your message. Please try again or email sales@astrabiocare.com.');
+    } finally {
+      setIsSubmitting(false);
+    }
   }
 
   return (
@@ -21,15 +34,43 @@ export default function Contact() {
       <h1 className="text-3xl md:text-4xl font-semibold mb-4">Contact &amp; Bulk Enquiries</h1>
       <p className="mb-6">For quotes, distribution partnerships, or regulatory documents, reach out to our team.</p>
       {submitted ? (
-        <p className="text-success">Thank you. We will respond within 2 business days.</p>
+        <p className="text-success" role="status">Thank you. We will respond within 2 business days.</p>
       ) : (
         <form onSubmit={handleSubmit} className="space-y-4">
-          <input name="name" placeholder="Name" className="w-full rounded-md border px-3 py-2" required />
-          <input name="email" type="email" placeholder="Email" className="w-full rounded-md border px-3 py-2" required />
-          <input name="phone" placeholder="Phone" className="w-full rounded-md border px-3 py-2" />
-          <input name="company" placeholder="Company" className="w-full rounded-md border px-3 py-2" />
-          <textarea name="message" placeholder="Message" className="w-full rounded-md border px-3 py-2" rows={4} required />
-          <button type="submit" className="rounded-md bg-primary px-5 py-2 text-white">Send</button>
+          <div className="space-y-1">
+            <label htmlFor="name" className="text-sm font-medium">Name</label>
+            <input id="name" name="name" autoComplete="name" className="w-full rounded-md border px-3 py-2" required />
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="email" className="text-sm font-medium">Email</label>
+            <input id="email" name="email" type="email" autoComplete="email" className="w-full rounded-md border px-3 py-2" required />
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="phone" className="text-sm font-medium">Phone</label>
+            <input id="phone" name="phone" autoComplete="tel" className="w-full rounded-md border px-3 py-2" />
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="company" className="text-sm font-medium">Company</label>
+            <input id="company" name="company" autoComplete="organization" className="w-full rounded-md border px-3 py-2" />
+          </div>
+          <input
+            type="text"
+            name="companyWebsite"
+            tabIndex={-1}
+            autoComplete="off"
+            className="hidden"
+            aria-hidden="true"
+          />
+          <div className="space-y-1">
+            <label htmlFor="message" className="text-sm font-medium">Message</label>
+            <textarea id="message" name="message" className="w-full rounded-md border px-3 py-2" rows={4} required />
+          </div>
+          {errorMessage ? (
+            <p className="text-sm text-danger" role="alert">{errorMessage}</p>
+          ) : null}
+          <button type="submit" disabled={isSubmitting} className="rounded-md bg-primary px-5 py-2 text-white disabled:opacity-60">
+            {isSubmitting ? 'Sending…' : 'Send'}
+          </button>
           <p className="text-xs text-gray-600">We respond within 2 business days. Your information is kept confidential.</p>
         </form>
       )}


### PR DESCRIPTION
### Motivation
- Prevent silent lead loss and improve UX by adding client-side validation, clear error states, and accessibility labels to the contact form.
- Reduce automated spam by adding a honeypot field and server-side validation for contact payloads.
- Harden the application by adding a baseline set of HTTP security headers to all responses.

### Description
- Updated `src/app/contact/page.tsx` to add accessible labels, `isSubmitting` state with a disabled submit button, an inline error message (`role="alert"`), and a hidden honeypot input named `companyWebsite` to detect bots.
- Updated `src/app/api/contact/route.ts` to validate incoming JSON safely, reject invalid or incomplete payloads with HTTP 400, honor the honeypot field by silently accepting bots, and enforce a maximum message length constant (`MAX_MESSAGE_LENGTH`).
- Updated `next.config.ts` to inject baseline security headers (e.g., `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, and `Strict-Transport-Security`) for all routes.

### Testing
- Launched the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`, and the `/contact` page compiled successfully (Next dev server ready), with warnings about Google Fonts failing to download and fallbacks used. (Successful)
- Ran an automated Playwright script that navigated to `http://127.0.0.1:3000/contact` and produced a screenshot at `artifacts/contact-form.png`, confirming the updated UI renders. (Successful)
- No unit tests or CI checks were executed in this change set, and `lint`/`build` were not run as part of automated testing. (Not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69677397a3ac833087733cc5375627b6)